### PR TITLE
use os.path.exists, not os.path.isfile

### DIFF
--- a/src/tp2ctl/tp2ctl.py
+++ b/src/tp2ctl/tp2ctl.py
@@ -1,7 +1,7 @@
 import argparse
 import re
 from os import listdir
-from os.path import realpath, join, isfile, isdir
+from os.path import realpath, exists, join, isdir
 from fcntl import ioctl
 from struct import pack
 
@@ -123,7 +123,7 @@ def main():
 
 
 def file_path(path):
-    if isfile(path):
+    if exists(path):
         return path
     else:
         raise argparse.ArgumentTypeError(


### PR DESCRIPTION
/dev/hidraw* files are all not regular files, but device files.

os.path.isfile will always return false, making it impossible to
explicitly specify a /dev/hidraw device to use.